### PR TITLE
Fix: CSS가 로드된 후 getHtml 메서드 실행

### DIFF
--- a/app/css/home.module.css
+++ b/app/css/home.module.css
@@ -1,4 +1,5 @@
 .home-container {
+  max-width: 980px;
   margin-bottom: 192px;
 }
 

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -72,13 +72,9 @@ button {
   margin: auto;
 }
 
-.container > * {
+.container__inner {
   margin: auto;
   width: 92%;
-}
-
-.main-container {
-  max-width: 980px;
 }
 
 /* NAV */

--- a/app/css/post.module.css
+++ b/app/css/post.module.css
@@ -1,0 +1,4 @@
+.post-container {
+  max-width: 700px;
+  margin-bottom: 192px;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -10,7 +10,7 @@
   <body>
     <nav class="navbar">
       <div class="container">
-        <div class="navbar-container">
+        <div class="container__inner navbar-container">
           <a href="/" aria-label="토스 기술 블로그, 토스테크">
             <img
               src="/public/toss_tech_logo.svg"
@@ -32,7 +32,7 @@
         </div>
       </div>
     </nav>
-    <div id="app" class="container main-container"></div>
+    <div id="app"></div>
     <script type="module" src="/app.js"></script>
   </body>
 </html>

--- a/app/routers/index.js
+++ b/app/routers/index.js
@@ -47,7 +47,7 @@ const router = async () => {
   }
 
   const view = new match.route.view(getParams(match));
-  document.querySelector("#app").innerHTML = await view.getHtml();
+  document.querySelector("#app").innerHTML = await view.render();
 
   if (!view.executeViewScript) return;
 

--- a/app/views/AbstractView.js
+++ b/app/views/AbstractView.js
@@ -7,18 +7,22 @@ export default class {
     document.title = title;
   }
 
-  async getHtml() {
+  getHtml() {
     return "";
   }
 
   loadCSS(path) {
-    const head = document.head;
-    const link = document.createElement("link");
+    return new Promise((resolve, reject) => {
+      const head = document.head;
+      const link = document.createElement("link");
 
-    link.type = "text/css";
-    link.rel = "stylesheet";
-    link.href = path;
+      link.type = "text/css";
+      link.rel = "stylesheet";
+      link.href = path;
+      link.onload = () => resolve();
+      link.onerror = () => reject(`Could not load CSS at ${path}`);
 
-    head.appendChild(link);
+      head.appendChild(link);
+    });
   }
 }

--- a/app/views/DesignView.js
+++ b/app/views/DesignView.js
@@ -6,9 +6,13 @@ export default class extends AbstractView {
     this.setTitle("토스 기술 블로그, 토스디자인");
   }
 
-  async getHtml() {
+  getHtml() {
     return `
     <h1>Design Page</h1>
     `;
+  }
+
+  render() {
+    return this.getHtml();
   }
 }

--- a/app/views/Home.js
+++ b/app/views/Home.js
@@ -6,10 +6,9 @@ export default class extends AbstractView {
   constructor(params) {
     super(params);
     this.setTitle("토스 기술 블로그, 토스테크");
-    this.loadCSS("/css/home.module.css");
   }
 
-  async getHtml() {
+  getHtml() {
     const postsHtml = MOCK_POSTS.map(
       (post) => `
         <li class="post-item">
@@ -26,10 +25,15 @@ export default class extends AbstractView {
     ).join("");
 
     return `
-    <div class="home-container">
+    <div class="container__inner home-container">
       <h1>개발</h1>
       <ul class="post-list">${postsHtml}</ul>
     </div>
     `;
+  }
+
+  async render() {
+    await this.loadCSS("/css/home.module.css");
+    return this.getHtml();
   }
 }

--- a/app/views/PostView.js
+++ b/app/views/PostView.js
@@ -6,19 +6,26 @@ export default class extends AbstractView {
   constructor(params) {
     super(params);
     this.postId = params.id;
-    this.setTitle("Post");
+    this.setTitle(MOCK_POSTS[this.postId].title);
   }
 
-  async getHtml() {
+  getHtml() {
     const post = MOCK_POSTS[this.postId];
     return `
-      <img src="${post.thumbnailImg}" alt="${post.title}" />
-      <h1>${post.title}</h1>
-      <div>
-        <p>${post.author}</p>
-        <p>${formatDate(post.date)}</p>
+      <div class="container__inner post-container">
+        <img src="${post.thumbnailImg}" alt="${post.title}" />
+        <h1>${post.title}</h1>
+        <div>
+          <p>${post.author}</p>
+          <p>${formatDate(post.date)}</p>
+        </div>
+        ${post.contents}
       </div>
-      ${post.contents}
     `;
+  }
+
+  async render() {
+    await this.loadCSS("/css/post.module.css");
+    return this.getHtml();
   }
 }

--- a/app/views/Test.js
+++ b/app/views/Test.js
@@ -6,7 +6,7 @@ export default class extends AbstractView {
     super(params);
   }
 
-  async getHtml() {
+  getHtml() {
     return `
         <h1>Test Page</1>
         <main>
@@ -16,7 +16,11 @@ export default class extends AbstractView {
         `;
   }
 
-  async executeViewScript() {
+  executeViewScript() {
     setupCounter();
+  }
+
+  render() {
+    return this.getHtml();
   }
 }


### PR DESCRIPTION
## 문제 상황

CSS가 완전히 로드되기 전 [스타일링이 적용되지 않는 콘텐츠가 잠깐 뜨는 현상(Flash of unstyled content)](https://ko.wikipedia.org/wiki/FOUC)이 발생했습니다. 사용자 경험 향상을 위해 아래와 같은 방법으로 이 문제를 해결했습니다.

![스크린샷 2023-12-04 오전 12 17 59](https://github.com/okdol1/VanillaJS-SPA/assets/76744586/d45bb3da-6410-4469-82c4-c1441d2ed94b)
![스크린샷 2023-12-04 오전 12 18 06](https://github.com/okdol1/VanillaJS-SPA/assets/76744586/12fe8d01-e5b6-4240-93e3-7760cdcd4f7b)
![스크린샷 2023-12-04 오전 12 18 16](https://github.com/okdol1/VanillaJS-SPA/assets/76744586/029a9afc-ac72-4adf-80a6-bfc558fa3ac4)


## 해결 방법
문제를 해결하기 위해, CSS 파일이 완전히 로드되고 난 후에 HTML을 렌더링하도록 `loadCSS()` 메서드를 비동기적으로 처리했습니다.
- 프라미스를 생성하고 [onload 이벤트](https://www.w3schools.com/jsref/event_onload.asp)를 통해 CSS 파일이 완전히 로드되었는지 확인합니다. 
- 프라미스가 이행되면 `getHtml()` 메서드를 호출합니다.

![스크린샷 2023-12-04 오전 12 26 08](https://github.com/okdol1/VanillaJS-SPA/assets/76744586/7a61b071-055b-42d5-a410-734d5ef26381)
![스크린샷 2023-12-04 오전 12 26 13](https://github.com/okdol1/VanillaJS-SPA/assets/76744586/23f7b75d-728c-4dba-a6d6-1bce6276cfc8)
