### PR TITLE
Fix: Webpack DevServer에서 SPA 라우팅 관련 404 에러 해결

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -3,12 +3,12 @@ import router, { navigateTo, goToTossCareer } from "./routers/index";
 const setupEventListeners = () => {
   document.body.addEventListener("click", (e) => {
     const target = e.target;
-    if (!(target instanceof Element)) return;
+    if (!(target instanceof HTMLAnchorElement)) return;
 
     if (target.matches("[data-link]")) {
       e.preventDefault();
-      target instanceof HTMLAnchorElement &&
-        navigateTo((target as HTMLAnchorElement).href);
+
+      target instanceof HTMLAnchorElement && navigateTo(target.href);
     }
   });
 };

--- a/app/components/Post.ts
+++ b/app/components/Post.ts
@@ -1,7 +1,8 @@
+import { PostData } from "../types/index";
 import dayjs from "../utils/dayjs";
 import PostFeedback from "./PostFeedback";
 
-const Post = ({ post }: { post: any }) => {
+const Post = ({ post }: { post: PostData }) => {
   const formattedDate = dayjs(post.date).format("YYYY-MM-DD");
   return `
     <div class="container__inner post-container">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,7 @@ module.exports = {
     extensions: [".ts", ".js"],
   },
   devServer: {
+    historyApiFallback: true,
     static: {
       directory: path.join(__dirname, "dist"),
     },


### PR DESCRIPTION
- any 타입 제거
- webpack devServer 객체에서 `historyApiFallback` 활성화

## 이슈

-  webpack-dev-server에서 다른 페이지로 이동 시 404 에러 발생

### 문제원인

- SPA(Single Page Application)의 라우팅이 서버 사이드에서 인식되지 않아 문제 발생

SPA에서 클라이언트 사이드 라우팅을 사용하여 다른 경로로 이동할 때, 페이지를 다시 로드하지 않고도 내용을 동적으로 변경합니다. 이 과정에서 브라우저의 기본 동작을 방해하게 되며, 직접 URL을 입력하거나 새로 고침을 할 경우 서버는 해당 경로에 맞는 실제 파일을 찾지 못하여 404 에러를 반환합니다.

### 해결방법

- `webpack.config.js` 파일에 devServer `historyApiFallback `를 활성화

`historyApiFallback`를 활성화하면, 서버에 존재하지 않는 경로에 대한 요청을 받을 때 서버가 자동으로 `index.html` 페이지로 redirection합니다. 이를 통해 클라이언트 사이드 라우터가 URL 경로를 올바르게 인식하고, 적절한 라우팅 처리를 할 수 있게 됩니다. 결과적으로 사용자가 애플리케이션 내의 다른 경로로 이동하거나 페이지를 새로 고침해도, SPA가 정상적으로 작동하여 404 오류를 방지할 수 있습니다.

